### PR TITLE
Add DBLP support.

### DIFF
--- a/gscholar-bibtex.el
+++ b/gscholar-bibtex.el
@@ -272,11 +272,16 @@
    (gscholar-bibtex--replace-html-entities
     (replace-regexp-in-string "<.*?>" "" s))))
 
+(defun gscholar-bibtex--url-retrieve-as-buffer (url)
+  (let ((response-buffer (url-retrieve-synchronously url)))
+    (with-current-buffer response-buffer
+      (gscholar-bibtex--delete-response-header))
+    response-buffer))
+
 (defun gscholar-bibtex--url-retrieve-as-string (url)
-  (let ((response-buffer (url-retrieve-synchronously url))
+  (let ((response-buffer (gscholar-bibtex--url-retrieve-as-buffer url))
         retval)
     (with-current-buffer response-buffer
-      (gscholar-bibtex--delete-response-header)
       (setq retval (buffer-string)))
     (kill-buffer response-buffer)
     retval))


### PR DESCRIPTION
These changes add support for querying the [DBLP computer science bibliography](http://dblp.uni-trier.de/). Queries use DBLP’s XML interface, as a more stable alternative to HTML screen-scraping. Responses are parsed using Lisp-based XML parsing tools that already ship standard with Emacs, so this change creates no nonstandard build-time or run-time dependencies.

Getting this to work correctly with accented (non-ASCII) names was a bit subtle, but I’ve tested it and confirmed that it works correctly. It would be wise to test the other services to see how they do with such names, but at least for DBLP I can say it works as it should.