### PR TITLE
Fabricate a cookie to inject for url-retrieve (issue #12)

### DIFF
--- a/gscholar-bibtex.el
+++ b/gscholar-bibtex.el
@@ -607,13 +607,24 @@
 ;;; Google Scholar
 (defun gscholar-bibtex-google-scholar-search-results (query)
   (let* ((url-request-method "GET")
+	 ;; Fabricate a cookie with a random ID that expires in an hour.
          (random-id (format "%016x" (random (expt 16 16))))
-         (url-request-extra-headers
-          `(("Cookie" . ,(concat "GSP=ID=" random-id ":CF=4")))))
+	 (expiration (format-time-string "%a, %d %b %Y %H:%M:%S.00 %Z"
+					 (time-add (current-time)
+						   (seconds-to-time 3600)) t))
+         (my-cookie (mapconcat #'identity
+			       (list (format "GSP=ID=%s:CF=4; " random-id)
+				     (format "expires=%s" expiration)
+				     "path=/"
+				     "domain=scholar.google.com")
+			       "; ")))
+    (let ((url-current-object
+	   (url-generic-parse-url "http://scholar.google.com ") ))
+      (url-cookie-handle-set-cookie my-cookie))
     (gscholar-bibtex--url-retrieve-as-string
-     (concat  "http://scholar.google.com/scholar?q="
-              (url-hexify-string
-               (replace-regexp-in-string " " "\+" query))))))
+     (concat "http://scholar.google.com/scholar?q="
+	     (url-hexify-string
+	      (replace-regexp-in-string " " "\+" query))))))
 
 (defun gscholar-bibtex-google-scholar-bibtex-urls (buffer-content)
   (gscholar-bibtex-re-search buffer-content "\\(/scholar\.bib.*?\\)\"" 1))


### PR DESCRIPTION
Unfortunately, adding a cookie as an extra header ends up with multiple
cookie headers, which isn't really allowed in current HTTP
specifications, and not accepted by Google in any case. (There is a
comment in url-cookie.el complaining about servers that don't accept
multiple Cookie: headers, but the current specs are clear on this now.)

So we inject a new cookie into the Emacs cookie storage, set to expire
an hour from now.