### PR TITLE
Remove extraneous bug-causing space in domain.

### DIFF
--- a/gscholar-bibtex.el
+++ b/gscholar-bibtex.el
@@ -619,7 +619,7 @@
 				     "domain=scholar.google.com")
 			       "; ")))
     (let ((url-current-object
-	   (url-generic-parse-url "http://scholar.google.com ") ))
+	   (url-generic-parse-url "http://scholar.google.com") ))
       (url-cookie-handle-set-cookie my-cookie))
     (gscholar-bibtex--url-retrieve-as-string
      (concat "http://scholar.google.com/scholar?q="


### PR DESCRIPTION
This is pretty embarrassing. An extra space in the string naming "scholar.google.com" causes the fabricated cookie not to be set properly, but it wasn't obvious right away because there was still a working cookie stored in Emacs. This patch simply removes that space.