### PR TITLE
Suggestion: change to use https URL for Google Scholar by default.

### DIFF
--- a/gscholar-bibtex.el
+++ b/gscholar-bibtex.el
@@ -653,7 +653,7 @@
 
 (defun gscholar-bibtex-google-scholar-bibtex-content (bibtex-url)
   (gscholar-bibtex--url-retrieve-as-string
-   (concat "http://scholar.google.com" bibtex-url)))
+   (concat "https://scholar.google.com" bibtex-url)))
 
 ;;; DBLP
 (defun gscholar-bibtex-dblp-search-results (query)


### PR DESCRIPTION
Google Scholar uses https, so use it in the base URL.
This avoids the overhead of handling a redirect.