### PR TITLE
Clean some punctuation from queries.

### DIFF
--- a/gscholar-bibtex.el
+++ b/gscholar-bibtex.el
@@ -636,9 +636,17 @@
           (url-generic-parse-url "http://scholar.google.com")))
     (url-cookie-handle-set-cookie my-cookie)
     (gscholar-bibtex--url-retrieve-as-string
-     (concat "http://scholar.google.com/scholar?q="
-             (url-hexify-string
-              (replace-regexp-in-string " " "\+" query))))))
+     (concat "https://scholar.google.com/scholar?q="
+             ;; To prepare the query string, we need to:
+             ;; 1. Remove some extraneous puncutation.
+             ;; 2. Hex-encode it.
+             ;; 3. Convert encoded spaces to +
+             ;; If we encode spaces as + first, url-hexify-string
+             ;; hex-encodes the + symbols, and they are not interpreted
+             ;; properly as spaces on the server.
+             (replace-regexp-in-string "%20" "\+"
+                                       (url-hexify-string
+                                        (replace-regexp-in-string "[:,]" "" query)))))))
 
 (defun gscholar-bibtex-google-scholar-bibtex-urls (buffer-content)
   (gscholar-bibtex-re-search buffer-content "\\(/scholar\.bib.*?\\)\"" 1))


### PR DESCRIPTION
Some punctuation in a query can confuse the lookups on Google Scholar.
Such punctuation is unusual (but possible) in queries typed by a user,
but it is more likely in machine-generated queries.

Also, to format the query string, query terms need to be separated by
+ symbols. However, url-hexify-string hex-encodes the + symbols, so
they are not interpreted as separators by the server. So we hexify
first, then replace hex-encoded space characters by + in the query.