### PR TITLE
Use kill-buffer-and-window instead of delete-window

### DIFF
--- a/gscholar-bibtex.el
+++ b/gscholar-bibtex.el
@@ -437,7 +437,7 @@
         (entry-window (get-buffer-window gscholar-bibtex-entry-buffer-name)))
     (when entry-window
       (select-window entry-window)
-      (delete-window)
+      (kill-buffer-and-window)
       (select-window gscholar-window))))
 
 (defun gscholar-bibtex-quit-gscholar-window ()
@@ -452,7 +452,7 @@
             (not (buffer-live-p gscholar-bibtex-caller-buffer)))
         (next-buffer)
       (if caller-window
-          (progn (delete-window) (select-window caller-window))
+          (progn (kill-buffer-and-window) (select-window caller-window))
         (switch-to-buffer gscholar-bibtex-caller-buffer))))
   (message ""))
 


### PR DESCRIPTION
Former implementation with delete-window left the gscholar-bibtex search and BibTex Entry buffers open in the background after using `q` to quit the search. There is no need to keep them around and it can mess up the history of used buffers.